### PR TITLE
feat: add platform_utils with cross-platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,4 +287,11 @@ See [TODO.md](TODO.md) for the full task list.
 
 ---
 
+## Shortcuts
+
+```bash
+## run tests
+docker run --rm -v $(pwd):/app local-agent-collective:test pytest tests/ -v
+```
+
 > **"Your data stays with you."**

--- a/backend/core/platform_utils.py
+++ b/backend/core/platform_utils.py
@@ -1,0 +1,104 @@
+"""
+platform_utils.py
+
+Cross-platform path and command management.
+All platform-specific logic is centralized here.
+No other module should contain platform checks.
+"""
+
+import platform
+import os
+import subprocess
+from pathlib import Path
+
+
+class PlatformUtils:
+    """Handles all platform-specific operations."""
+
+    OS = platform.system()  # "Linux" | "Darwin" | "Windows"
+
+    @staticmethod
+    def get_base_dir() -> Path:
+        """
+        Returns the base data directory for the application.
+
+        Linux  : ~/.local/share/local-agent-collective/
+        macOS  : ~/Library/Application Support/local-agent-collective/
+        Windows: C:/Users/<user>/AppData/Local/local-agent-collective/
+        """
+        os_name = platform.system()
+        home = Path.home()
+
+        if os_name == "Linux":
+            base = home / ".local" / "share" / "local-agent-collective"
+        elif os_name == "Darwin":
+            base = home / "Library" / "Application Support" / "local-agent-collective"
+        elif os_name == "Windows":
+            app_data = os.environ.get("LOCALAPPDATA", str(home / "AppData" / "Local"))
+            base = Path(app_data) / "local-agent-collective"
+        else:
+            base = home / "local-agent-collective"
+
+        base.mkdir(parents=True, exist_ok=True)
+        return base
+
+    @staticmethod
+    def get_ollama_url() -> str:
+        """
+        Returns the Ollama API base URL.
+        Checks for environment variable override first (useful for Docker).
+        """
+        return os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+
+    @staticmethod
+    def is_ollama_running() -> bool:
+        """
+        Checks whether the Ollama service is currently running.
+
+        Linux/macOS : checks via ps
+        Windows     : checks via tasklist
+        """
+        os_name = platform.system()
+
+        try:
+            if os_name == "Windows":
+                result = subprocess.run(
+                    ["tasklist", "/FI", "IMAGENAME eq ollama.exe"],
+                    capture_output=True,
+                    text=True,
+                )
+                return "ollama.exe" in result.stdout
+            else:
+                result = subprocess.run(
+                    ["pgrep", "-x", "ollama"],
+                    capture_output=True,
+                    text=True,
+                )
+                return result.returncode == 0
+        except FileNotFoundError:
+            return False
+
+    @staticmethod
+    def get_ollama_install_instructions() -> str:
+        """
+        Returns platform-specific Ollama installation instructions.
+        """
+        os_name = platform.system()
+
+        instructions = {
+            "Linux": "curl -fsSL https://ollama.ai/install.sh | sh",
+            "Darwin": "brew install ollama  or  https://ollama.ai/download",
+            "Windows": "Download installer from https://ollama.ai/download",
+        }
+
+        return instructions.get(os_name, "Visit https://ollama.ai/download")
+
+    @staticmethod
+    def get_vector_store_dir() -> Path:
+        """Returns the ChromaDB vector store directory."""
+        return PlatformUtils.get_base_dir() / "vector_store"
+
+    @staticmethod
+    def get_documents_dir() -> Path:
+        """Returns the user documents directory."""
+        return PlatformUtils.get_base_dir() / "documents"

--- a/reports/cross_platform_utils_support_26Feb.md
+++ b/reports/cross_platform_utils_support_26Feb.md
@@ -1,0 +1,8 @@
+add platform_utils with cross-platform support:
+
+- get_base_dir() for Linux/macOS/Windows
+- get_ollama_url() with env variable override
+- is_ollama_running() via pgrep/tasklist
+- get_ollama_install_instructions()
+- get_vector_store_dir() and get_documents_dir()
+- 8 unit tests, all passing"

--- a/tests/backend/test_platform_utils.py
+++ b/tests/backend/test_platform_utils.py
@@ -1,0 +1,61 @@
+"""
+Tests for platform_utils.py
+"""
+
+import platform
+from pathlib import Path
+from backend.core.platform_utils import PlatformUtils
+
+
+def test_get_base_dir_returns_path():
+    base = PlatformUtils.get_base_dir()
+    assert isinstance(base, Path)
+    assert base.exists()
+
+
+def test_get_base_dir_platform_specific():
+    base = PlatformUtils.get_base_dir()
+    os_name = platform.system()
+
+    if os_name == "Linux":
+        assert ".local/share/local-agent-collective" in str(base)
+    elif os_name == "Darwin":
+        assert "Application Support/local-agent-collective" in str(base)
+    elif os_name == "Windows":
+        assert "local-agent-collective" in str(base)
+
+
+def test_get_ollama_url_default():
+    import os
+    os.environ.pop("OLLAMA_BASE_URL", None)
+    url = PlatformUtils.get_ollama_url()
+    assert url == "http://localhost:11434"
+
+
+def test_get_ollama_url_env_override(monkeypatch):
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://ollama:11434")
+    url = PlatformUtils.get_ollama_url()
+    assert url == "http://ollama:11434"
+
+
+def test_is_ollama_running_returns_bool():
+    result = PlatformUtils.is_ollama_running()
+    assert isinstance(result, bool)
+
+
+def test_get_ollama_install_instructions_not_empty():
+    instructions = PlatformUtils.get_ollama_install_instructions()
+    assert isinstance(instructions, str)
+    assert len(instructions) > 0
+
+
+def test_get_vector_store_dir():
+    path = PlatformUtils.get_vector_store_dir()
+    assert isinstance(path, Path)
+    assert "vector_store" in str(path)
+
+
+def test_get_documents_dir():
+    path = PlatformUtils.get_documents_dir()
+    assert isinstance(path, Path)
+    assert "documents" in str(path)


### PR DESCRIPTION
## Summary
add platform_utils with cross-platform support

## Changes
backend/core/platform_utils.py 
- get_base_dir() for Linux/macOS/Windows
- get_ollama_url() with env variable override
- is_ollama_running() via pgrep/tasklist
- get_ollama_install_instructions()
- get_vector_store_dir() and get_documents_dir()
- 8 unit tests, all passing"

## Related Issue
Closes #

## Type of Change
- [X] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `chore` — infrastructure / tooling
- [ ] `docs` — documentation
- [ ] `test` — tests only

## Checklist
- [x] Code follows project style (flake8 + black)
- [x] Tests added or updated
- [x] Documentation updated if needed
- [x] Docker build tested locally
- [x] No direct push to `main` or `dev`
