### PR TITLE
2 feature/ollama client

### DIFF
--- a/backend/core/ollama_client.py
+++ b/backend/core/ollama_client.py
@@ -1,0 +1,234 @@
+"""
+ollama_client.py
+
+Async HTTP client for communicating with the local Ollama API.
+All model interactions go through this module.
+"""
+
+import json
+import asyncio
+import httpx
+from typing import Optional
+from backend.core.platform_utils import PlatformUtils
+
+
+class OllamaConnectionError(Exception):
+    """Raised when Ollama service is unreachable."""
+    pass
+
+
+class OllamaModelError(Exception):
+    """Raised when a model operation fails."""
+    pass
+
+
+class OllamaClient:
+    """Async client for the Ollama API."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        retry_attempts: int = 3,
+        retry_delay: float = 2.0,
+        timeout: float = 120.0,
+    ):
+        self.base_url = base_url or PlatformUtils.get_ollama_url()
+        self.retry_attempts = retry_attempts
+        self.retry_delay = retry_delay
+        self.timeout = timeout
+
+    async def ping(self) -> bool:
+        """
+        Check if Ollama service is reachable.
+
+        Returns:
+            True if reachable, False otherwise.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(f"{self.base_url}/api/tags")
+                return response.status_code == 200
+        except Exception:
+            return False
+
+    async def list_models(self) -> list[dict]:
+        """
+        List all locally installed models.
+
+        Returns:
+            List of model info dicts.
+
+        Raises:
+            OllamaConnectionError: If Ollama is unreachable.
+        """
+        response = await self._request("GET", "/api/tags")
+        return response.get("models", [])
+
+    async def pull_model(self, model_id: str) -> bool:
+        """
+        Pull (download) a model from Ollama registry.
+
+        Args:
+            model_id: Model identifier e.g. 'qwen3:4b'
+
+        Returns:
+            True if successful.
+
+        Raises:
+            OllamaModelError: If pull fails.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=600.0) as client:
+                async with client.stream(
+                    "POST",
+                    f"{self.base_url}/api/pull",
+                    json={"name": model_id},
+                ) as response:
+                    async for line in response.aiter_lines():
+                        if line:
+                            data = json.loads(line)
+                            status = data.get("status", "")
+                            if "error" in data:
+                                raise OllamaModelError(
+                                    f"Failed to pull {model_id}: {data['error']}"
+                                )
+                            if status == "success":
+                                return True
+            return True
+        except OllamaModelError:
+            raise
+        except Exception as e:
+            raise OllamaModelError(f"Failed to pull {model_id}: {e}") from e
+
+    async def chat(
+        self,
+        model: str,
+        messages: list[dict],
+        keep_alive: str = "0",
+        stream: bool = False,
+    ) -> str:
+        """
+        Send a chat completion request to Ollama.
+
+        Args:
+            model: Model identifier e.g. 'qwen3:4b'
+            messages: List of message dicts with 'role' and 'content'
+            keep_alive: How long to keep model in memory. '0' = unload immediately
+            stream: Whether to stream the response
+
+        Returns:
+            Model response as string.
+
+        Raises:
+            OllamaConnectionError: If Ollama is unreachable.
+            OllamaModelError: If model is not available.
+        """
+        payload = {
+            "model": model,
+            "messages": messages,
+            "keep_alive": keep_alive,
+            "stream": stream,
+        }
+        response = await self._request("POST", "/api/chat", payload)
+        return response.get("message", {}).get("content", "")
+
+    async def embed(self, model: str, text: str) -> list[float]:
+        """
+        Generate embeddings for the given text.
+
+        Args:
+            model: Embedding model e.g. 'nomic-embed-text:v1.5'
+            text: Text to embed
+
+        Returns:
+            Embedding vector as list of floats.
+
+        Raises:
+            OllamaConnectionError: If Ollama is unreachable.
+            OllamaModelError: If embedding fails.
+        """
+        payload = {"model": model, "input": text}
+        response = await self._request("POST", "/api/embed", payload)
+        embeddings = response.get("embeddings", [])
+        if not embeddings:
+            raise OllamaModelError(f"No embeddings returned for model {model}")
+        return embeddings[0]
+
+    async def unload_model(self, model: str) -> bool:
+        """
+        Unload a model from memory immediately.
+
+        Args:
+            model: Model identifier to unload
+
+        Returns:
+            True if successful.
+        """
+        try:
+            await self._request(
+                "POST",
+                "/api/chat",
+                {
+                    "model": model,
+                    "messages": [],
+                    "keep_alive": "0",
+                },
+            )
+            return True
+        except Exception:
+            return False
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        payload: Optional[dict] = None,
+    ) -> dict:
+        """
+        Internal method to make HTTP requests with retry logic.
+
+        Args:
+            method: HTTP method (GET, POST)
+            endpoint: API endpoint path
+            payload: Request body
+
+        Returns:
+            Response as dict.
+
+        Raises:
+            OllamaConnectionError: After all retry attempts fail.
+        """
+        url = f"{self.base_url}{endpoint}"
+        last_error = None
+
+        for attempt in range(1, self.retry_attempts + 1):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    if method == "GET":
+                        response = await client.get(url)
+                    else:
+                        response = await client.post(url, json=payload)
+
+                    response.raise_for_status()
+                    return response.json()
+
+            except httpx.ConnectError as e:
+                last_error = e
+                if attempt < self.retry_attempts:
+                    await asyncio.sleep(self.retry_delay)
+
+            except httpx.HTTPStatusError as e:
+                raise OllamaModelError(
+                    f"Ollama API error {e.response.status_code}: {e.response.text}"
+                ) from e
+
+            except Exception as e:
+                last_error = e
+                if attempt < self.retry_attempts:
+                    await asyncio.sleep(self.retry_delay)
+
+        raise OllamaConnectionError(
+            f"Cannot connect to Ollama at {self.base_url} "
+            f"after {self.retry_attempts} attempts. "
+            f"Is Ollama running? Run: {PlatformUtils.get_ollama_install_instructions()}"
+        ) from last_error

--- a/backend/core/ollama_client.py
+++ b/backend/core/ollama_client.py
@@ -14,11 +14,13 @@ from backend.core.platform_utils import PlatformUtils
 
 class OllamaConnectionError(Exception):
     """Raised when Ollama service is unreachable."""
+
     pass
 
 
 class OllamaModelError(Exception):
     """Raised when a model operation fails."""
+
     pass
 
 

--- a/reports/changelog_26Feb.md
+++ b/reports/changelog_26Feb.md
@@ -1,0 +1,19 @@
+feat 1: add platform_utils with cross-platform support:
+
+- get_base_dir() for Linux/macOS/Windows
+- get_ollama_url() with env variable override
+- is_ollama_running() via pgrep/tasklist
+- get_ollama_install_instructions()
+- get_vector_store_dir() and get_documents_dir()
+- 8 unit tests, all passing"
+
+feat 2: add ollama_client with async HTTP and retry logic
+
+- ping() to check Ollama availability
+- list_models() to fetch installed models
+- pull_model() with streaming support
+- chat() with keep_alive=0 default (lazy unload)
+- embed() for vector generation
+- unload_model() to free VRAM
+- retry logic: configurable attempts and delay
+- 12 unit tests, all passing"

--- a/reports/cross_platform_utils_support_26Feb.md
+++ b/reports/cross_platform_utils_support_26Feb.md
@@ -1,8 +1,0 @@
-add platform_utils with cross-platform support:
-
-- get_base_dir() for Linux/macOS/Windows
-- get_ollama_url() with env variable override
-- is_ollama_running() via pgrep/tasklist
-- get_ollama_install_instructions()
-- get_vector_store_dir() and get_documents_dir()
-- 8 unit tests, all passing"

--- a/tests/backend/test_ollama_client.py
+++ b/tests/backend/test_ollama_client.py
@@ -1,0 +1,154 @@
+"""
+Tests for ollama_client.py
+
+Note: These tests use mocking — no real Ollama connection needed.
+Real integration tests will be added when Docker Compose is fully set up.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from backend.core.ollama_client import OllamaClient, OllamaConnectionError, OllamaModelError
+
+
+@pytest.fixture
+def client():
+    """Create a test OllamaClient instance."""
+    return OllamaClient(
+        base_url="http://localhost:11434",
+        retry_attempts=2,
+        retry_delay=0.1,
+    )
+
+
+# --- ping ---
+
+@pytest.mark.asyncio
+async def test_ping_success(client):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("httpx.AsyncClient") as mock_http:
+        mock_http.return_value.__aenter__.return_value.get = AsyncMock(
+            return_value=mock_response
+        )
+        result = await client.ping()
+        assert result is True
+
+
+@pytest.mark.asyncio
+async def test_ping_failure(client):
+    with patch("httpx.AsyncClient") as mock_http:
+        mock_http.return_value.__aenter__.return_value.get = AsyncMock(
+            side_effect=Exception("connection refused")
+        )
+        result = await client.ping()
+        assert result is False
+
+
+# --- list_models ---
+
+@pytest.mark.asyncio
+async def test_list_models_success(client):
+    mock_data = {"models": [{"name": "qwen3:4b"}, {"name": "deepseek-r1:7b"}]}
+
+    with patch.object(client, "_request", new=AsyncMock(return_value=mock_data)):
+        models = await client.list_models()
+        assert len(models) == 2
+        assert models[0]["name"] == "qwen3:4b"
+
+
+@pytest.mark.asyncio
+async def test_list_models_empty(client):
+    with patch.object(client, "_request", new=AsyncMock(return_value={"models": []})):
+        models = await client.list_models()
+        assert models == []
+
+
+# --- chat ---
+
+@pytest.mark.asyncio
+async def test_chat_success(client):
+    mock_data = {"message": {"role": "assistant", "content": "Hello!"}}
+
+    with patch.object(client, "_request", new=AsyncMock(return_value=mock_data)):
+        response = await client.chat(
+            model="qwen3:4b",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        assert response == "Hello!"
+
+
+@pytest.mark.asyncio
+async def test_chat_keep_alive_default(client):
+    mock_data = {"message": {"content": "response"}}
+
+    with patch.object(client, "_request", new=AsyncMock(return_value=mock_data)) as mock_req:
+        await client.chat(model="qwen3:4b", messages=[])
+        call_args = mock_req.call_args
+        assert call_args[0][2]["keep_alive"] == "0"
+
+
+# --- embed ---
+
+@pytest.mark.asyncio
+async def test_embed_success(client):
+    mock_data = {"embeddings": [[0.1, 0.2, 0.3]]}
+
+    with patch.object(client, "_request", new=AsyncMock(return_value=mock_data)):
+        vector = await client.embed(model="nomic-embed-text:v1.5", text="hello")
+        assert vector == [0.1, 0.2, 0.3]
+
+
+@pytest.mark.asyncio
+async def test_embed_empty_response_raises(client):
+    with patch.object(client, "_request", new=AsyncMock(return_value={"embeddings": []})):
+        with pytest.raises(OllamaModelError):
+            await client.embed(model="nomic-embed-text:v1.5", text="hello")
+
+
+# --- unload_model ---
+
+@pytest.mark.asyncio
+async def test_unload_model_success(client):
+    with patch.object(client, "_request", new=AsyncMock(return_value={})):
+        result = await client.unload_model("qwen3:4b")
+        assert result is True
+
+
+@pytest.mark.asyncio
+async def test_unload_model_failure_returns_false(client):
+    with patch.object(client, "_request", new=AsyncMock(side_effect=Exception("error"))):
+        result = await client.unload_model("qwen3:4b")
+        assert result is False
+
+
+# --- _request retry logic ---
+
+@pytest.mark.asyncio
+async def test_request_retries_on_connection_error(client):
+    import httpx
+
+    with patch("httpx.AsyncClient") as mock_http:
+        mock_http.return_value.__aenter__.return_value.get = AsyncMock(
+            side_effect=httpx.ConnectError("refused")
+        )
+        with pytest.raises(OllamaConnectionError):
+            await client._request("GET", "/api/tags")
+
+
+@pytest.mark.asyncio
+async def test_request_raises_model_error_on_http_status(client):
+    import httpx
+
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.text = "model not found"
+
+    with patch("httpx.AsyncClient") as mock_http:
+        mock_http.return_value.__aenter__.return_value.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "not found", request=MagicMock(), response=mock_response
+            )
+        )
+        with pytest.raises(OllamaModelError):
+            await client._request("POST", "/api/chat", {})


### PR DESCRIPTION
## Summary
ollama_client with async HTTP and retry logic

## Changes
backend/core/ollama_client.py

- ping() to check Ollama availability
- list_models() to fetch installed models
- pull_model() with streaming support
- chat() with keep_alive=0 default (lazy unload)
- embed() for vector generation
- unload_model() to free VRAM
- retry logic: configurable attempts and delay
- 12 unit tests, all passing"

## Related Issue
Closes #2 

## Type of Change
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `chore` — infrastructure / tooling
- [ ] `docs` — documentation
- [ ] `test` — tests only

## Checklist
- [x] Code follows project style (flake8 + black)
- [x] Tests added or updated
- [x] Documentation updated if needed
- [x] Docker build tested locally
- [x] No direct push to `main` or `dev`
