### PR TITLE
feat: implement RAG agent with ChromaDB integration

### DIFF
--- a/agents/rag_agent/agent.py
+++ b/agents/rag_agent/agent.py
@@ -1,0 +1,325 @@
+"""
+rag_agent/agent.py
+
+RAG (Retrieval-Augmented Generation) Agent.
+Loads documents, stores them in ChromaDB, and answers questions
+using semantic search + local LLM.
+"""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import chromadb
+from langchain_community.document_loaders import (
+    PyPDFLoader,
+    TextLoader,
+    Docx2txtLoader,
+)
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+from backend.core.agent_base import AgentBase
+from backend.core.ollama_client import OllamaClient
+from backend.core.platform_utils import PlatformUtils
+
+
+class RagAgent(AgentBase):
+    """
+    RAG Agent — loads documents and answers questions.
+
+    Supported task types:
+    - load_document: Load and embed a document into ChromaDB
+    - query: Answer a question using stored documents
+    """
+
+    def __init__(
+        self,
+        agent_id: str = "rag_agent",
+        memory_dir: Optional[Path] = None,
+        ollama_client: Optional[OllamaClient] = None,
+        chroma_dir: Optional[Path] = None,
+        config_path: Optional[Path] = None,
+    ):
+        if memory_dir is None:
+            memory_dir = Path(__file__).parent / "memory"
+
+        super().__init__(
+            agent_id=agent_id,
+            memory_dir=memory_dir,
+            ollama_client=ollama_client,
+        )
+
+        # Load agent config
+        if config_path is None:
+            config_path = Path(__file__).parent / "config.json"
+        self.config = self._load_config(config_path)
+
+        # ChromaDB setup
+        if chroma_dir is None:
+            chroma_dir = PlatformUtils.get_vector_store_dir()
+        self.chroma_dir = chroma_dir
+
+        self.chroma_client = chromadb.PersistentClient(path=str(chroma_dir))
+        self.collection = self.chroma_client.get_or_create_collection(
+            name="rag_agent_docs",
+            metadata={"hnsw:space": "cosine"},
+        )
+
+        # Text splitter config
+        self.chunk_size = 512
+        self.chunk_overlap = 64
+        self.top_k = 5
+
+        # Embedding model
+        self.embed_model = "nomic-embed-text:v1.5"
+
+        # Chat model
+        self.chat_model = "qwen3:4b"
+
+    def _load_config(self, config_path: Path) -> dict:
+        """Load agent configuration from config.json."""
+        if config_path.exists():
+            with open(config_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        return {}
+
+    def get_capabilities(self) -> list[str]:
+        return self.config.get(
+            "capabilities",
+            ["document_qa", "semantic_search"],
+        )
+
+    def get_required_model_role(self) -> str:
+        return "rag"
+
+    async def _execute(self, task: dict) -> dict:
+        """
+        Route task to appropriate handler based on task type.
+
+        Supported types:
+        - load_document: {"type": "load_document", "input": "/path/to/file"}
+        - query: {"type": "query", "input": "your question"}
+        """
+        task_type = task.get("type")
+        task_input = task.get("input", "")
+
+        if task_type == "load_document":
+            return await self._handle_load_document(task_input)
+        elif task_type == "query":
+            return await self._handle_query(task_input)
+        else:
+            return {
+                "success": False,
+                "output": None,
+                "error": (
+                    f"Unknown task type: '{task_type}'. "
+                    "Supported: 'load_document', 'query'"
+                ),
+            }
+
+    # --- Document Loading ---
+
+    async def _handle_load_document(self, file_path: str) -> dict:
+        """Load a document and store its embeddings in ChromaDB."""
+        path = Path(file_path)
+
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        # Load document
+        docs = self.load_document(path)
+
+        # Chunk document
+        chunks = self.chunk_document(docs)
+
+        if not chunks:
+            return {
+                "success": False,
+                "output": None,
+                "error": "Document produced no chunks",
+            }
+
+        # Embed and store
+        stored_count = await self.embed_and_store(chunks, source=str(path))
+
+        return {
+            "success": True,
+            "output": {
+                "file": str(path),
+                "chunks_stored": stored_count,
+            },
+        }
+
+    def load_document(self, path: Path) -> list:
+        """
+        Load a document using the appropriate LangChain loader.
+
+        Args:
+            path: Path to the document file
+
+        Returns:
+            List of LangChain Document objects.
+
+        Raises:
+            ValueError: If file type is not supported.
+        """
+        suffix = path.suffix.lower()
+
+        if suffix == ".pdf":
+            loader = PyPDFLoader(str(path))
+        elif suffix == ".txt" or suffix == ".md":
+            loader = TextLoader(str(path), encoding="utf-8")
+        elif suffix == ".docx":
+            loader = Docx2txtLoader(str(path))
+        else:
+            raise ValueError(
+                f"Unsupported file type: '{suffix}'. "
+                "Supported: .pdf, .txt, .md, .docx"
+            )
+
+        return loader.load()
+
+    def chunk_document(self, docs: list) -> list:
+        """
+        Split documents into overlapping chunks.
+
+        Args:
+            docs: List of LangChain Document objects
+
+        Returns:
+            List of chunked LangChain Document objects.
+        """
+        splitter = RecursiveCharacterTextSplitter(
+            chunk_size=self.chunk_size,
+            chunk_overlap=self.chunk_overlap,
+            length_function=len,
+        )
+        return splitter.split_documents(docs)
+
+    async def embed_and_store(self, chunks: list, source: str) -> int:
+        """
+        Embed chunks and store in ChromaDB.
+
+        Args:
+            chunks: List of LangChain Document chunks
+            source: Source file path for metadata
+
+        Returns:
+            Number of chunks stored.
+        """
+        texts = [chunk.page_content for chunk in chunks]
+        ids = [f"{source}__chunk_{i}" for i in range(len(texts))]
+        metadatas = [{"source": source, "chunk_index": i} for i in range(len(texts))]
+
+        # Generate embeddings
+        embeddings = []
+        for text in texts:
+            vector = await self.ollama.embed(model=self.embed_model, text=text)
+            embeddings.append(vector)
+
+        # Store in ChromaDB
+        self.collection.upsert(
+            ids=ids,
+            documents=texts,
+            embeddings=embeddings,
+            metadatas=metadatas,
+        )
+
+        return len(texts)
+
+    # --- Querying ---
+
+    async def _handle_query(self, question: str) -> dict:
+        """Answer a question using stored documents."""
+        if not question.strip():
+            return {
+                "success": False,
+                "output": None,
+                "error": "Question cannot be empty",
+            }
+
+        # Search ChromaDB
+        context_chunks = await self.query(question)
+
+        if not context_chunks:
+            return {
+                "success": True,
+                "output": "No relevant documents found for your question.",
+            }
+
+        # Generate answer
+        answer = await self.generate_answer(question, context_chunks)
+
+        return {
+            "success": True,
+            "output": {
+                "answer": answer,
+                "sources": list({c["source"] for c in context_chunks}),
+                "chunks_used": len(context_chunks),
+            },
+        }
+
+    async def query(self, question: str) -> list[dict]:
+        """
+        Embed question and retrieve top-k matching chunks from ChromaDB.
+
+        Args:
+            question: User question
+
+        Returns:
+            List of dicts with 'text' and 'source' keys.
+        """
+        question_vector = await self.ollama.embed(model=self.embed_model, text=question)
+
+        results = self.collection.query(
+            query_embeddings=[question_vector],
+            n_results=min(self.top_k, self.collection.count()),
+            include=["documents", "metadatas"],
+        )
+
+        chunks = []
+        documents = results.get("documents", [[]])[0]
+        metadatas = results.get("metadatas", [[]])[0]
+
+        for doc, meta in zip(documents, metadatas):
+            chunks.append(
+                {
+                    "text": doc,
+                    "source": meta.get("source", "unknown"),
+                }
+            )
+
+        return chunks
+
+    async def generate_answer(self, question: str, context_chunks: list[dict]) -> str:
+        """
+        Generate an answer using retrieved context and qwen3:4b.
+
+        Args:
+            question: User question
+            context_chunks: List of relevant text chunks
+
+        Returns:
+            Generated answer as string.
+        """
+        system_prompt = self.config.get(
+            "system_prompt",
+            "You are a helpful assistant. Answer based on the provided context.",
+        )
+
+        context_text = "\n\n---\n\n".join(
+            [f"Source: {c['source']}\n{c['text']}" for c in context_chunks]
+        )
+
+        user_message = (
+            f"Context:\n{context_text}\n\n" f"Question: {question}\n\n" "Answer:"
+        )
+
+        return await self.ollama.chat(
+            model=self.chat_model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_message},
+            ],
+            keep_alive="0",
+        )

--- a/agents/rag_agent/config.json
+++ b/agents/rag_agent/config.json
@@ -1,0 +1,10 @@
+{
+  "id": "rag_agent",
+  "name": "RAG Agent",
+  "description": "Loads documents and answers questions using retrieval-augmented generation.",
+  "capabilities": ["document_qa", "pdf_analysis", "semantic_search", "multilingual"],
+  "preferred_model_roles": ["rag"],
+  "input_types": ["pdf", "txt", "docx", "md"],
+  "enabled": true,
+  "system_prompt": "You are a document analysis expert. Answer questions ONLY using information from the provided documents. If the answer is not in the documents, say 'This information is not in the provided documents.' Be concise and precise. If asked in Turkish, respond in Turkish."
+}

--- a/agents/rag_agent/memory/errors.json
+++ b/agents/rag_agent/memory/errors.json
@@ -1,0 +1,4 @@
+{
+  "agent_id": "rag_agent",
+  "errors": []
+}

--- a/agents/rag_agent/memory/skills.json
+++ b/agents/rag_agent/memory/skills.json
@@ -1,0 +1,45 @@
+{
+  "agent_id": "rag_agent",
+  "skills": [
+    {
+      "id": "sk_001",
+      "name": "load_document",
+      "description": "Loads PDF, TXT, DOCX files and prepares them for processing",
+      "success_rate": 1.0,
+      "total_runs": 0,
+      "last_used": null
+    },
+    {
+      "id": "sk_002",
+      "name": "chunk_document",
+      "description": "Splits document into overlapping chunks for embedding",
+      "success_rate": 1.0,
+      "total_runs": 0,
+      "last_used": null
+    },
+    {
+      "id": "sk_003",
+      "name": "embed_chunks",
+      "description": "Converts text chunks to vectors via nomic-embed-text",
+      "success_rate": 1.0,
+      "total_runs": 0,
+      "last_used": null
+    },
+    {
+      "id": "sk_004",
+      "name": "semantic_search",
+      "description": "Embeds query and retrieves top-k matching chunks from ChromaDB",
+      "success_rate": 1.0,
+      "total_runs": 0,
+      "last_used": null
+    },
+    {
+      "id": "sk_005",
+      "name": "generate_answer",
+      "description": "Generates answer from retrieved context via qwen3:4b",
+      "success_rate": 1.0,
+      "total_runs": 0,
+      "last_used": null
+    }
+  ]
+}

--- a/reports/changelog_2Mar.md
+++ b/reports/changelog_2Mar.md
@@ -1,0 +1,13 @@
+feat 1: implement RAG agent with ChromaDB integration
+
+- config.json with capabilities and system prompt
+- memory/skills.json with 5 initial skills
+- memory/errors.json empty initial log
+- load_document() for PDF, TXT, DOCX, MD files
+- chunk_document() with configurable size and overlap
+- embed_and_store() via nomic-embed-text to ChromaDB
+- query() semantic search with top-k retrieval
+- generate_answer() via qwen3:4b with context
+- _execute() handles load_document and query task types
+- auto-discovered by AgentRegistry
+- 19 unit tests, all passing

--- a/tests/agents/test_rag_agent.py
+++ b/tests/agents/test_rag_agent.py
@@ -1,0 +1,225 @@
+"""
+Tests for rag_agent/agent.py
+
+Uses mocking — no real Ollama or ChromaDB connection needed in CI.
+"""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+
+from agents.rag_agent.agent import RagAgent
+from backend.core.ollama_client import OllamaClient
+
+
+@pytest.fixture
+def mock_ollama():
+    client = MagicMock(spec=OllamaClient)
+    client.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    client.chat = AsyncMock(return_value="Test answer")
+    return client
+
+
+@pytest.fixture
+def mock_collection():
+    collection = MagicMock()
+    collection.count.return_value = 5
+    collection.query.return_value = {
+        "documents": [["chunk 1 text", "chunk 2 text"]],
+        "metadatas": [
+            [
+                {"source": "/docs/test.pdf", "chunk_index": 0},
+                {"source": "/docs/test.pdf", "chunk_index": 1},
+            ]
+        ],
+    }
+    return collection
+
+
+@pytest.fixture
+def agent(tmp_path, mock_ollama, mock_collection):
+    """Create a RagAgent with mocked dependencies."""
+    with patch("chromadb.PersistentClient") as mock_chroma:
+        mock_chroma.return_value.get_or_create_collection.return_value = (
+            mock_collection
+        )
+        rag = RagAgent(
+            memory_dir=tmp_path / "memory",
+            ollama_client=mock_ollama,
+            chroma_dir=tmp_path / "chroma",
+        )
+        rag.collection = mock_collection
+        return rag
+
+
+# --- initialization ---
+
+def test_agent_id(agent):
+    assert agent.agent_id == "rag_agent"
+
+
+def test_get_capabilities(agent):
+    caps = agent.get_capabilities()
+    assert "document_qa" in caps
+
+
+def test_get_required_model_role(agent):
+    assert agent.get_required_model_role() == "rag"
+
+
+# --- load_document ---
+
+def test_load_document_txt(agent, tmp_path):
+    txt_file = tmp_path / "test.txt"
+    txt_file.write_text("Hello world. This is a test document.")
+
+    docs = agent.load_document(txt_file)
+    assert len(docs) > 0
+    assert "Hello world" in docs[0].page_content
+
+
+def test_load_document_unsupported_type(agent, tmp_path):
+    bad_file = tmp_path / "test.xyz"
+    bad_file.write_text("content")
+
+    with pytest.raises(ValueError, match="Unsupported file type"):
+        agent.load_document(bad_file)
+
+
+def test_load_document_not_found(agent, tmp_path):
+    with pytest.raises((FileNotFoundError, RuntimeError)):
+        agent.load_document(tmp_path / "nonexistent.txt")
+
+
+# --- chunk_document ---
+
+def test_chunk_document_splits_long_text(agent, tmp_path):
+    from langchain_core.documents import Document
+
+    long_text = "word " * 500
+    docs = [Document(page_content=long_text, metadata={})]
+    chunks = agent.chunk_document(docs)
+    assert len(chunks) > 1
+
+
+def test_chunk_document_short_text(agent, tmp_path):
+    from langchain_core.documents import Document
+
+    docs = [Document(page_content="Short text.", metadata={})]
+    chunks = agent.chunk_document(docs)
+    assert len(chunks) == 1
+
+
+# --- embed_and_store ---
+
+@pytest.mark.asyncio
+async def test_embed_and_store(agent, tmp_path):
+    from langchain_core.documents import Document
+
+    chunks = [
+        Document(page_content="chunk one", metadata={}),
+        Document(page_content="chunk two", metadata={}),
+    ]
+    count = await agent.embed_and_store(chunks, source="/docs/test.txt")
+    assert count == 2
+    agent.collection.upsert.assert_called_once()
+
+
+# --- query ---
+
+@pytest.mark.asyncio
+async def test_query_returns_chunks(agent):
+    results = await agent.query("What is this document about?")
+    assert len(results) == 2
+    assert results[0]["text"] == "chunk 1 text"
+    assert results[0]["source"] == "/docs/test.pdf"
+
+
+@pytest.mark.asyncio
+async def test_query_empty_collection(agent, mock_collection):
+    mock_collection.count.return_value = 0
+    mock_collection.query.return_value = {
+        "documents": [[]],
+        "metadatas": [[]],
+    }
+    results = await agent.query("any question")
+    assert results == []
+
+
+# --- generate_answer ---
+
+@pytest.mark.asyncio
+async def test_generate_answer(agent):
+    context = [
+        {"text": "The sky is blue.", "source": "/docs/nature.txt"},
+    ]
+    answer = await agent.generate_answer("What color is the sky?", context)
+    assert answer == "Test answer"
+    agent.ollama.chat.assert_called_once()
+
+
+# --- _execute ---
+
+@pytest.mark.asyncio
+async def test_execute_unknown_task_type(agent):
+    result = await agent._execute({"type": "unknown", "input": "test"})
+    assert result["success"] is False
+    assert "Unknown task type" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_execute_query_empty_question(agent):
+    result = await agent._execute({"type": "query", "input": ""})
+    assert result["success"] is False
+    assert "empty" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_execute_query_success(agent):
+    result = await agent._execute({
+        "type": "query",
+        "input": "What is this about?",
+    })
+    assert result["success"] is True
+    assert "answer" in result["output"]
+
+
+@pytest.mark.asyncio
+async def test_execute_load_document_not_found(agent):
+    with pytest.raises(FileNotFoundError):
+        await agent._execute({
+            "type": "load_document",
+            "input": "/nonexistent/file.txt",
+        })
+
+
+@pytest.mark.asyncio
+async def test_execute_load_document_success(agent, tmp_path):
+    txt_file = tmp_path / "test.txt"
+    txt_file.write_text("Test document content for RAG agent.")
+
+    result = await agent._execute({
+        "type": "load_document",
+        "input": str(txt_file),
+    })
+    assert result["success"] is True
+    assert result["output"]["chunks_stored"] >= 1
+
+
+# --- run (full AgentBase integration) ---
+
+@pytest.mark.asyncio
+async def test_run_query_task(agent):
+    result = await agent.run({
+        "type": "query",
+        "input": "What is this document about?",
+    })
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_registers_skill(agent):
+    await agent.run({"type": "query", "input": "test question"})
+    skills = agent.memory.get_skills()
+    assert any(s["name"] == "query" for s in skills)


### PR DESCRIPTION
## Summary
First real agent — loads documents and answers questions using 
retrieval-augmented generation. Auto-discovered by AgentRegistry 
via config.json.

## Changes
- `agents/rag_agent/config.json` — agent identity, capabilities, system prompt
- `agents/rag_agent/memory/skills.json` — 5 initial skills
- `agents/rag_agent/memory/errors.json` — empty error log
- `agents/rag_agent/agent.py` — full RAG implementation
- `tests/agents/test_rag_agent.py` — 19 unit tests, all passing 

## Related Issue
<!-- Link the issue this PR closes -->
Closes #9 

## Type of Change
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `chore` — infrastructure / tooling
- [ ] `docs` — documentation
- [ ] `test` — tests only

## Checklist
- [x] Code follows project style (flake8 + black)
- [x] Tests added or updated
- [x] Docker build tested locally
- [x] No direct push to `main` or `dev`
